### PR TITLE
Adds requiresMainQueueSetup

### DIFF
--- a/ios/RNInCallManager/RNInCallManager.m
+++ b/ios/RNInCallManager/RNInCallManager.m
@@ -61,6 +61,11 @@
     NSString *_media;
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 RCT_EXPORT_MODULE(InCallManager)
 
 - (instancetype)init


### PR DESCRIPTION
Fixed error being throw `"RNInCallManager requires main queue setup 
since it overrides `init` but doesn't implement `requiresMainQueueSetup`".`